### PR TITLE
msm: vidc: Suppress false error messages

### DIFF
--- a/drivers/media/platform/msm/vidc/msm_v4l2_vidc.c
+++ b/drivers/media/platform/msm/vidc/msm_v4l2_vidc.c
@@ -406,7 +406,7 @@ static int __devinit msm_vidc_probe(struct platform_device *pdev)
 		goto err_core_init;
 	}
 	if (core->hfi_type == VIDC_HFI_Q6) {
-		dprintk(VIDC_ERR, "Q6 hfi device probe called\n");
+		dprintk(VIDC_DBG, "Q6 hfi device probe called\n");
 		nr += MSM_VIDC_MAX_DEVICES;
 		core->id = MSM_VIDC_CORE_Q6;
 	} else {

--- a/drivers/media/platform/msm/vidc/msm_vidc_res_parse.c
+++ b/drivers/media/platform/msm/vidc/msm_vidc_res_parse.c
@@ -186,6 +186,13 @@ static int msm_vidc_load_reg_table(struct msm_vidc_platform_resources *res)
 	int i;
 	int rc = 0;
 
+	if (!of_find_property(pdev->dev.of_node, "qcom,reg-presets", NULL)) {
+		/* qcom,reg-presets is an optional property.  It likely won't be
+		 * present if we don't have any register settings to program */
+		dprintk(VIDC_DBG, "qcom,reg-presets not found\n");
+		return 0;
+	}
+
 	reg_set = &res->reg_set;
 	reg_set->count = get_u32_array_num_elements(pdev, "qcom,reg-presets");
 	if (reg_set->count == 0) {
@@ -221,6 +228,13 @@ static int msm_vidc_load_freq_table(struct msm_vidc_platform_resources *res)
 	int rc = 0;
 	int num_elements = 0;
 	struct platform_device *pdev = res->pdev;
+
+	if (!of_find_property(pdev->dev.of_node, "qcom,load-freq-tbl", NULL)) {
+		/* qcom,load-freq-tbl is an optional property.  It likely won't
+		 * be present on cores that we can't clock scale on. */
+		dprintk(VIDC_DBG, "qcom,load-freq-tbl not found\n");
+		return 0;
+	}
 
 	num_elements = get_u32_array_num_elements(pdev, "qcom,load-freq-tbl");
 	if (num_elements == 0) {
@@ -512,6 +526,15 @@ static int msm_vidc_load_buffer_usage_table(
 	int rc = 0;
 	struct platform_device *pdev = res->pdev;
 	struct buffer_usage_set *buffer_usage_set = &res->buffer_usage_set;
+
+	if (!of_find_property(pdev->dev.of_node,
+				"qcom,buffer-type-tz-usage-table", NULL)) {
+		/* qcom,buffer-type-tz-usage-table is an optional property.  It
+		 * likely won't be present if the core doesn't support content
+		 * protection */
+		dprintk(VIDC_DBG, "buffer-type-tz-usage-table not found\n");
+		return 0;
+	}
 
 	buffer_usage_set->count = get_u32_array_num_elements(
 				    pdev, "qcom,buffer-type-tz-usage-table");


### PR DESCRIPTION
When parsing the device tree the driver emits false error messages when
optional properties are not found.  This commit gracefully handles the
absence of optional properties.

Change-Id: I34c58513e8fa62e6862b8c630814930554ff18fb
Signed-off-by: Deva Ramasubramanian <dramasub@codeaurora.org>